### PR TITLE
improve automatic test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pyandoc
 frontend/bower_components
 frontend/node_modules
 settings/local_settings.py
+coverage

--- a/fabfile/development/__init__.py
+++ b/fabfile/development/__init__.py
@@ -196,3 +196,13 @@ def tdd():
     with lcd(FRONTENDDIR):
         cmd = '%(gulp)s tdd' % {'gulp': get_gulp()}
         local(cmd)
+
+@task
+def watch():
+    """
+    Watch files changes to build
+    """
+
+    with lcd(FRONTENDDIR):
+        cmd = '%(gulp)s watch' % {'gulp': get_gulp()}
+        local(cmd)

--- a/fabfile/development/__init__.py
+++ b/fabfile/development/__init__.py
@@ -177,7 +177,6 @@ def deploy():
         run("cp -r build build-old")
         put('build', '.')
 
-
 @task
 def test():
     """
@@ -185,5 +184,15 @@ def test():
     """
 
     with lcd(FRONTENDDIR):
-        cmd = '%(npm)s test' % {'npm': get_npm()}
+        cmd = '%(gulp)s test' % {'gulp': get_gulp()}
+        local(cmd)
+
+@task
+def tdd():
+    """
+    Watch files changes to run frontend tests
+    """
+
+    with lcd(FRONTENDDIR):
+        cmd = '%(gulp)s tdd' % {'gulp': get_gulp()}
         local(cmd)

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "chai": "~2.1.1",
     "sinon": "~1.13.0",
-    "sinon-chai": "~2.7.0"
+    "sinon-chai": "~2.7.0",
+    "chai-jquery": "~2.0.0"
   }
 }

--- a/frontend/bower.json
+++ b/frontend/bower.json
@@ -18,6 +18,8 @@
     "tests"
   ],
   "devDependencies": {
-    "chai": "~2.1.1"
+    "chai": "~2.1.1",
+    "sinon": "~1.13.0",
+    "sinon-chai": "~2.7.0"
   }
 }

--- a/frontend/gulpfile.js
+++ b/frontend/gulpfile.js
@@ -65,6 +65,15 @@ gulp.task('test', function (done) {
   });
 });
 
+gulp.task('tdd', function (done) {
+  karma.start({
+    configFile: __dirname + '/karma.conf.js',
+    singleRun: false
+  }, function(exitStatus){
+    done(exitStatus ? "There are failing unit tests" : undefined);
+  });
+});
+
 gulp.task('server', ['build', 'watch']);
 
 gulp.task('watch', function() {

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -19,8 +19,9 @@ module.exports = function(config) {
       {pattern: 'frontend/src/javascripts/**/*.js', included: false},
       {pattern: 'frontend/test/**/*.test.js', included: false},
       {pattern: 'static/vendor/**/*.js', included: false},
-      {pattern: 'frontend/bower_components/chai/**/*.js', included: false},
-      {pattern: 'frontend/bower_components/sinon*/lib/**/*.js', included: false}
+      {pattern: 'frontend/bower_components/chai*/**/*.js', included: false},
+      {pattern: 'frontend/bower_components/sinon*/lib/**/*.js', included: false},
+      {pattern: 'frontend/node_modules/lolex/lolex.js', included: false}
     ],
 
 

--- a/frontend/karma.conf.js
+++ b/frontend/karma.conf.js
@@ -19,7 +19,8 @@ module.exports = function(config) {
       {pattern: 'frontend/src/javascripts/**/*.js', included: false},
       {pattern: 'frontend/test/**/*.test.js', included: false},
       {pattern: 'static/vendor/**/*.js', included: false},
-      {pattern: 'frontend/bower_components/chai/**/*.js', included: false}
+      {pattern: 'frontend/bower_components/chai/**/*.js', included: false},
+      {pattern: 'frontend/bower_components/sinon*/lib/**/*.js', included: false}
     ],
 
 
@@ -31,13 +32,14 @@ module.exports = function(config) {
     // preprocess matching files before serving them to the browser
     // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
     preprocessors: {
+      'frontend/src/javascripts/**/*.js': ['coverage']
     },
 
 
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['mocha'],
+    reporters: ['mocha', 'coverage'],
 
 
     // web server port
@@ -54,7 +56,7 @@ module.exports = function(config) {
 
 
     // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: false,
+    autoWatch: true,
 
 
     // start these browsers
@@ -64,6 +66,13 @@ module.exports = function(config) {
 
     // Continuous Integration mode
     // if true, Karma captures browsers, runs the tests and exits
-    singleRun: true
+    singleRun: true,
+
+    coverageReporter: {
+      reporters:[
+        {type: 'html', dir:'coverage/'},
+        {type: 'text-summary'}
+      ],
+    }
   });
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "karma-mocha": "~0.1.10",
     "karma": "~0.12.31",
     "karma-requirejs": "~0.2.2",
-    "karma-phantomjs-launcher": "~0.1.4"
+    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-coverage": "~0.2.7"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "karma": "~0.12.31",
     "karma-requirejs": "~0.2.2",
     "karma-phantomjs-launcher": "~0.1.4",
-    "karma-coverage": "~0.2.7"
+    "karma-coverage": "~0.2.7",
+    "lolex": "~1.2.1"
   }
 }

--- a/frontend/test/datatable.test.js
+++ b/frontend/test/datatable.test.js
@@ -1,4 +1,224 @@
 define(['chai', 'sinon', 'pubsub', 'datatable'],
 function(chai, sinon, pubsub, DataTable) {
-  
+  'use strict';
+
+  var expect = chai.expect;
+
+  var respond = function(server, url, num, total, id) {
+    url = url != null ? url : '/api_url?page=0&per_page_num=10&param1=foo&param2=bar&param3=spam';
+    num = num != null ? num : 10;
+    total = total != null ? num : 100;
+    id = id != null ? id : '';
+    var content = '[';
+    for (var i=1; i <= num; i++) {
+      content += '{ "col1": "' + id + i + ',1", "col2": "' + id + i + ',2", "col3": "' + id + i + ',3" }';
+      if (i < num) content += ',';
+    }
+    content += ']';
+    var headers = {
+      'Content-Type': 'application/json',
+      'X-Total-Count': total
+    };
+    server.respondWith('GET', url, [ 200, headers, content ]);
+  };
+
+  describe('DataTable', function() {
+    var opts,
+        el,
+        parent = $('<div>'),
+        dataTable,
+        server;
+
+    beforeEach(function() {
+      server = sinon.fakeServer.create();
+
+      el = $('<table>');
+      parent.append(el);
+
+      opts = {
+        url: '/api_url',
+        columns: [
+          {field: 'col1', title: 'Column 1'},
+          {field: 'col2', title: 'Column 2'},
+          {field: 'col3', title: 'Column 3'}
+        ],
+        params: {
+          param1: 'foo',
+          param2: 'bar',
+          param3: 'spam',
+          param4: null
+        },
+        pubsub: pubsub
+      };
+
+      respond(server, null, 2);
+      dataTable = new DataTable(el, opts);
+      server.respond();
+    });
+
+    afterEach(function() {
+      dataTable.destroy();
+      pubsub.clearAllSubscriptions();
+      parent.empty();
+      server.restore();
+    });
+
+    describe('Initialization', function() {
+      it('should accept any type of element', function() {
+        el = $('<div>');
+        expect(function () {
+          new DataTable(el, opts)
+        }).to.not.throw("'null' is not an object (evaluating 'settings.nTable')")
+      });
+
+      it('should create table header', function() {
+        var $thead = el.children('thead');
+        expect($thead.length).to.be.equal(1);
+        expect($thead.find('th').length).to.be.equal(opts.columns.length);
+        expect($thead.find('th').eq(0)).to.have.text(opts.columns[0].title);
+        expect($thead.find('th').eq(1)).to.have.text(opts.columns[1].title);
+        expect($thead.find('th').eq(2)).to.have.text(opts.columns[2].title);
+      });
+
+      it('should initialize datatables plugin', function() {
+        expect(dataTable.$el).to.have.class('dataTable');
+      });
+
+      it('should draw first page', function() {
+        el = $('<table>');
+        parent = $('<div>').append(el);
+        respond(server, null, 2, 2);
+        new DataTable(el, opts);
+        server.respond();
+        expect(el.find('tbody tr').length).to.be.equal(2);
+        expect(el.find('tbody tr').eq(0).find('td').first()).to.have.text('1,1');
+        expect(el.find('tbody tr').eq(1).find('td').eq(2)).to.have.text('2,3');
+        expect(parent.find('.dataTables_info')).to.have.text('Showing 1 to 2 of 2 entries');
+      });
+
+      it('should initialize without a pubsub instance', function() {
+        opts.pubsub = undefined;
+        var dataTable;
+        expect(function () {
+          dataTable = new DataTable($('<table>'), opts);
+        }).to.not.throw("'undefined' is not an object (evaluating 'that.pubsub.subscribe')");
+        server.respond();
+      });
+    });
+
+    describe('Formatters', function() {
+      it('should call the defined formatters', function() {
+        var spy = sinon.spy();
+        opts.formatters = { col1: function (val) { spy(val); return val; } };
+        respond(server, null, 2, 2);
+        new DataTable($('<table>'), opts);
+        server.respond();
+        expect(spy).to.have.been.calledTwice;
+      });
+
+      it('should ignore formatters for invalid columns', function() {
+        var spy = sinon.spy();
+        opts.formatters = { bla: spy };
+        respond(server, null, 2, 2);
+        new DataTable($('<table>'), opts);
+        expect(spy).to.not.have.been.called;
+        server.respond();
+      });
+
+      it('should ignore invalid formatters', function() {
+        var spy = sinon.spy();
+        opts.formatters = { col1: null };
+        respond(server, null, 2, 2);
+        new DataTable($('<table>'), opts);
+        expect(spy).to.not.have.been.called;
+        server.respond();
+      });
+    });
+
+    describe('Pub/Sub integration', function() {
+      it('should publish "page.changed" when paginating', function(done) {
+        var spy = sinon.spy(pubsub, 'publish'),
+            clock = sinon.useFakeTimers(0);
+        el.on('page.dt', function () {
+          expect(spy).to.have.been.calledOnce;
+          expect(spy).to.have.been.calledWith('page.changed');
+          pubsub.publish.restore();
+          done();
+        });
+        parent.find('a.next').click();
+        clock.tick(1);
+        clock.restore();
+      });
+
+      it('should publish "per_page_num.changed" and "page.changed" when user select the number of items to show', function(done) {
+          var spy = sinon.spy(pubsub, 'publish'),
+              clock = sinon.useFakeTimers();
+          el.on('length.dt', function () {
+            expect(spy).to.have.been.calledTwice;
+            expect(spy).to.have.been.calledWith('per_page_num.changed');
+            expect(spy).to.have.been.calledWith('page.changed');
+            pubsub.publish.restore();
+            done();
+          });
+          parent.find('select').change();
+          clock.tick(1);
+          clock.restore();
+      });
+
+      it('should react to "page.changed" message', function() {
+        expect(dataTable.getParam('page')).to.be.equal(0);
+        pubsub.publishSync('page.changed', { value: 2 });
+        expect(dataTable.getParam('page')).to.be.equal(2);
+      });
+
+      it('should react to "per_page_num.changed" message', function() {
+        expect(dataTable.getParam('per_page_num')).to.be.equal(10);
+        pubsub.publishSync('per_page_num.changed', { value: 15 });
+        expect(dataTable.getParam('per_page_num')).to.be.equal(15);
+      });
+
+      it('should reload after changing the value of a param', function() {
+        var len = server.requests.length;
+        pubsub.publishSync('param3.changed', { value: 'eggs' });
+        expect(server.requests.length).to.be.equal(len + 1);
+        server.respond();
+      });
+    });
+
+    describe('#setParam', function() {
+      it('should change "page" without a pubsub instance', function(done) {
+        opts.pubsub = undefined;
+        dataTable.pubsub = undefined;
+        el.on('page.dt', function () {
+          expect(dataTable.getParam('page')).to.be.equal(1);
+          done();
+        });
+        expect(function () {
+          dataTable.setParam('page', 1);
+        }).to.not.throw("'undefined' is not an object (evaluating 'this.pubsub.publish')");
+      });
+
+      it('should change "per_page_num" without a pubsub instance', function(done) {
+        opts.pubsub = undefined;
+        dataTable.pubsub = undefined;
+        el.on('length.dt', function () {
+          expect(dataTable.getParam('per_page_num')).to.be.equal(15);
+          done();
+        });
+        expect(function () {
+          dataTable.setParam('per_page_num', 15);
+        }).to.not.throw("'undefined' is not an object (evaluating 'this.pubsub.publish')");
+      });
+
+      it('should change a simple param without a pubsub instance', function() {
+        opts.pubsub = undefined;
+        dataTable.pubsub = undefined;
+        expect(dataTable.getParam('param1')).to.not.be.equal('eggs');
+        expect(function () {
+          dataTable.setParam('param1', 'eggs');
+        }).to.not.throw("'undefined' is not an object (evaluating 'this.pubsub.publish')");
+        expect(dataTable.getParam('param1')).to.be.equal('eggs');
+      });
+    });
+  });
 });

--- a/frontend/test/datatable.test.js
+++ b/frontend/test/datatable.test.js
@@ -1,0 +1,4 @@
+define(['chai', 'sinon', 'pubsub', 'datatable'],
+function(chai, sinon, pubsub, DataTable) {
+  
+});

--- a/frontend/test/test-main.js
+++ b/frontend/test/test-main.js
@@ -37,24 +37,33 @@
     // example of using shim, to load non AMD libraries (such as underscore and jquery)
     paths: {
 
-      chai: bowerComponentPath('chai/chai'),
+      'chai': bowerComponentPath('chai/chai'),
+      'sinon': bowerComponentPath('sinon/lib/sinon'),
+      'sinon-chai': bowerComponentPath('sinon-chai/lib/sinon-chai'),
 
-      jquery: vendorPath('jquery/js/jquery'),
-      riot : vendorPath('riotjs/js/riot'),
-      pubsub : vendorPath('pubsub-js/js/pubsub'),
-      datatables: vendorPath('datatables/js/jquery.dataTables')
+      'jquery': vendorPath('jquery/js/jquery'),
+      'riot': vendorPath('riotjs/js/riot'),
+      'pubsub': vendorPath('pubsub-js/js/pubsub'),
+      'datatables': vendorPath('datatables/js/jquery.dataTables')
     },
 
     shim: {
-      chai: {
+      'chai': {
         exports: 'chai'
+      },
+      'sinon': {
+        exports: 'sinon'
       }
     },
 
     // dynamically load all test files
     deps: allTestFiles,
 
-    // we have to kickoff jasmine, as it is asynchronous
+    // we have to kickoff mocha, as it is asynchronous
     callback: window.__karma__.start
+  });
+
+  require(['chai', 'sinon', 'sinon-chai'], function(chai, sinon, sinonChai) {
+    chai.use(sinonChai);
   });
 })();

--- a/frontend/test/test-main.js
+++ b/frontend/test/test-main.js
@@ -40,6 +40,8 @@
       'chai': bowerComponentPath('chai/chai'),
       'sinon': bowerComponentPath('sinon/lib/sinon'),
       'sinon-chai': bowerComponentPath('sinon-chai/lib/sinon-chai'),
+      'chai-jquery': bowerComponentPath('chai-jquery/chai-jquery'),
+      'lolex': nodeModulePath('lolex/lolex'),
 
       'jquery': vendorPath('jquery/js/jquery'),
       'riot': vendorPath('riotjs/js/riot'),
@@ -47,23 +49,38 @@
       'datatables': vendorPath('datatables/js/jquery.dataTables')
     },
 
+    // Workaround to set global `lolex`
+    map: {
+      '*': { 'lolex': 'lolex-global' },
+      'lolex-global': { 'lolex': 'lolex' }
+    },
+
     shim: {
       'chai': {
         exports: 'chai'
       },
       'sinon': {
-        exports: 'sinon'
+        exports: 'sinon',
+        deps: ['lolex']
       }
     },
 
     // dynamically load all test files
-    deps: allTestFiles,
+    deps: allTestFiles.concat(['lolex']),
 
     // we have to kickoff mocha, as it is asynchronous
     callback: window.__karma__.start
   });
 
-  require(['chai', 'sinon', 'sinon-chai'], function(chai, sinon, sinonChai) {
+  // Workaround to set global `lolex`
+  define('lolex-global', ['lolex'], function(lolex) {
+    window.lolex = lolex;
+    return lolex;
+  });
+
+  require(['chai', 'sinon', 'sinon-chai', 'chai-jquery'],
+  function(chai, sinon, sinonChai, chaiJquery) {
     chai.use(sinonChai);
+    chai.use(chaiJquery);
   });
 })();

--- a/frontend/test/urlmanager.test.js
+++ b/frontend/test/urlmanager.test.js
@@ -1,0 +1,74 @@
+define(['chai', 'sinon', 'pubsub', 'urlmanager'],
+function(chai, sinon, pubsub, UrlManager) {
+    var expect = chai.expect;
+
+    describe('UrlManager', function() {
+      var opts,
+          urlManager,
+          locationFake;
+
+      beforeEach(function() {
+        locationFake = {
+          hash: '',
+          href: ''
+        };
+        opts = {
+          format: "#{{param1}}/{{param2}}",
+          params: {
+            param1: 'foo',
+            param2: 'bar',
+            param3: 'spam'
+          },
+          pubsub: pubsub,
+          location: locationFake
+        };
+        urlManager = new UrlManager(opts);
+      });
+
+      afterEach(function() {
+        pubsub.clearAllSubscriptions();
+      });
+
+      describe('#constructor()', function() {
+        it('should get url from window.location by default', function() {
+           delete opts.location
+           urlManager = new UrlManager(opts);
+           expect(urlManager.location).to.be.equal(window.location);
+        });
+      });
+
+      describe('#extractParamsFromUrl()', function() {
+        it('should get the correct params', function() {
+          locationFake.href = '/base#param1Value/param2Value?param3=param3Value&optionalParam=optionalParamValue';
+          expect(urlManager.extractParamsFromUrl()).to.be.deep.equal({
+            param1: 'param1Value',
+            param2: 'param2Value',
+            param3: 'param3Value',
+            optionalParam: 'optionalParamValue'
+          });
+        });
+
+        it('should get default values for missing params', function() {
+          locationFake.href = '/base#param1Value';
+          expect(urlManager.extractParamsFromUrl()).to.be.deep.equal({
+            param1: 'param1Value',
+            param2: opts.params.param2,
+            param3: opts.params.param3
+          });
+        });
+      });
+
+      describe('Pub/Sub integration', function() {
+        it('should subscribe to all `PARAMNAME.changed` messages', function() {
+           var spy = sinon.spy(pubsub, 'subscribe');
+           urlManager = new UrlManager(opts);
+           expect(spy).to.have.been.calledThrice;
+           expect(spy).to.have.been.calledWith('param1.changed');
+           expect(spy).to.have.been.calledWith('param2.changed');
+           expect(spy).to.have.been.calledWith('param3.changed');
+           pubsub.subscribe.restore();
+        });
+      });
+
+    });
+});

--- a/frontend/test/urlmanager.test.js
+++ b/frontend/test/urlmanager.test.js
@@ -62,14 +62,14 @@ function(chai, sinon, pubsub, UrlManager) {
           expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
           locationFake.href = '/base#null/param2NewValue';
           urlManager.updateParams();
-          expect(urlManager.getParam('param1')).to.be.equal(null);
+          expect(urlManager.getParam('param1')).to.be.null;
         });
 
         it('should convert "undefined" string to null', function() {
           expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
           locationFake.href = '/base#undefined/param2NewValue';
           urlManager.updateParams();
-          expect(urlManager.getParam('param1')).to.be.equal(null);
+          expect(urlManager.getParam('param1')).to.be.null;
         });
       });
 
@@ -101,6 +101,7 @@ function(chai, sinon, pubsub, UrlManager) {
           var spy = sinon.spy(urlManager, 'broadcast');
           window.onhashchange();
           expect(spy).to.not.have.been.called;
+          urlManager.broadcast.restore();
         });
       });
 

--- a/frontend/test/urlmanager.test.js
+++ b/frontend/test/urlmanager.test.js
@@ -1,5 +1,7 @@
 define(['chai', 'sinon', 'pubsub', 'urlmanager'],
 function(chai, sinon, pubsub, UrlManager) {
+    'use strict';
+
     var expect = chai.expect;
 
     describe('UrlManager', function() {
@@ -13,7 +15,7 @@ function(chai, sinon, pubsub, UrlManager) {
           href: ''
         };
         opts = {
-          format: "#{{param1}}/{{param2}}",
+          format: "#{{param1}}/{{param2}}?{{params}}",
           params: {
             param1: 'foo',
             param2: 'bar',
@@ -29,46 +31,141 @@ function(chai, sinon, pubsub, UrlManager) {
         pubsub.clearAllSubscriptions();
       });
 
-      describe('#constructor()', function() {
+      describe('Initialization', function() {
         it('should get url from window.location by default', function() {
            delete opts.location
            urlManager = new UrlManager(opts);
            expect(urlManager.location).to.be.equal(window.location);
         });
+
+        it('should append "?{{params}}" to URL format if not present', function() {
+          opts.format = "#{{params1}}/{{param2}}";
+          urlManager = new UrlManager(opts);
+          expect(urlManager.format).to.be.equal("#{{params1}}/{{param2}}?{{params}}");
+        });
       });
 
-      describe('#extractParamsFromUrl()', function() {
-        it('should get the correct params', function() {
-          locationFake.href = '/base#param1Value/param2Value?param3=param3Value&optionalParam=optionalParamValue';
-          expect(urlManager.extractParamsFromUrl()).to.be.deep.equal({
-            param1: 'param1Value',
-            param2: 'param2Value',
-            param3: 'param3Value',
-            optionalParam: 'optionalParamValue'
-          });
+      describe('Parsers', function() {
+        it('should use parsers from initialization options', function() {
+          var spy = sinon.spy();
+          opts.parsers = {
+            param2: spy
+          };
+          urlManager = new UrlManager(opts);
+          locationFake.href = '/base#param1NewValue/param2NewValue';
+          urlManager.updateParams();
+          expect(spy).to.have.been.calledOnce;
+          expect(spy).to.have.been.calledWith('param2NewValue');
         });
 
-        it('should get default values for missing params', function() {
-          locationFake.href = '/base#param1Value';
-          expect(urlManager.extractParamsFromUrl()).to.be.deep.equal({
-            param1: 'param1Value',
-            param2: opts.params.param2,
-            param3: opts.params.param3
-          });
+        it('should convert "null" string to null', function() {
+          expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
+          locationFake.href = '/base#null/param2NewValue';
+          urlManager.updateParams();
+          expect(urlManager.getParam('param1')).to.be.equal(null);
+        });
+
+        it('should convert "undefined" string to null', function() {
+          expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
+          locationFake.href = '/base#undefined/param2NewValue';
+          urlManager.updateParams();
+          expect(urlManager.getParam('param1')).to.be.equal(null);
+        });
+      });
+
+      describe('onhashchange Event', function() {
+        it('should update params values after onhashchange', function() {
+          expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
+          locationFake.href = '/base#param1NewValue';
+          window.onhashchange();
+          expect(urlManager.getParam('param1')).to.be.equal('param1NewValue');
+          expect(urlManager.getParam('param2')).to.be.equal(opts.params.param2);
+          expect(urlManager.getParam('param3')).to.be.equal(opts.params.param3);
+        });
+
+        it('should update optional params values after onhashchange', function() {
+          expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
+          locationFake.href = '#?param3=param3NewValue';
+          window.onhashchange();
+          expect(urlManager.getParam('param3')).to.be.equal('param3NewValue');
+        });
+
+        it('should use an array for params with multiple values', function() {
+          expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
+          locationFake.href = '/base#param1/param2?param3=firstValue&param3=secondValue';
+          window.onhashchange();
+          expect(urlManager.getParam('param3')).to.be.deep.equal(['firstValue', 'secondValue']);
+        });
+
+        it('should ignore onhashchange if the location.href remains the same', function() {
+          var spy = sinon.spy(urlManager, 'broadcast');
+          window.onhashchange();
+          expect(spy).to.not.have.been.called;
+        });
+      });
+
+      describe('#setParam', function() {
+        it('should update URL', function() {
+          locationFake.hash = 'before';
+          urlManager.setParam('param1', 'param1NewValue');
+          expect(locationFake.hash).to.be.equal('#param1NewValue/bar');
+        });
+
+        it('should not update URL if setting the same current value', function() {
+          locationFake.hash = 'before';
+          urlManager.setParam('param1', opts.params.param1);
+          expect(locationFake.hash).to.be.equal('before');
+        });
+
+        it('should replace null values by blank string in URL', function() {
+          urlManager.setParam('param1', null);
+          expect(locationFake.hash).to.be.equal('#/bar');
+        });
+
+        it('should join main params array values with "-" in URL', function() {
+          urlManager.setParam('param1', ['first', 'second']);
+          expect(locationFake.hash).to.be.equal('#first-second/bar');
+        });
+
+        it('should use traditional "shallow" serialization to optional params', function() {
+          urlManager.setParam('param3', ['first', 'second']);
+          expect(locationFake.hash).to.be.equal('#foo/bar?param3=first&param3=second')
         });
       });
 
       describe('Pub/Sub integration', function() {
-        it('should subscribe to all `PARAMNAME.changed` messages', function() {
-           var spy = sinon.spy(pubsub, 'subscribe');
-           urlManager = new UrlManager(opts);
-           expect(spy).to.have.been.calledThrice;
-           expect(spy).to.have.been.calledWith('param1.changed');
-           expect(spy).to.have.been.calledWith('param2.changed');
-           expect(spy).to.have.been.calledWith('param3.changed');
-           pubsub.subscribe.restore();
+        it('should update params values after `PARAMNAME.changed` messages are published', function() {
+          expect(urlManager.getParam('param1')).to.be.equal(opts.params.param1);
+          pubsub.publishSync('param1.changed', {value: 'param1NewValue'});
+          expect(urlManager.getParam('param1')).to.be.equal('param1NewValue');
+
+          expect(urlManager.getParam('param2')).to.be.equal(opts.params.param2);
+          pubsub.publishSync('param2.changed', {value: 'param2NewValue'});
+          expect(urlManager.getParam('param2')).to.be.equal('param2NewValue');
+
+          expect(urlManager.getParam('param3')).to.be.equal(opts.params.param3);
+          pubsub.publishSync('param3.changed', {value: 'param3NewValue'});
+          expect(urlManager.getParam('param3')).to.be.equal('param3NewValue');
+        });
+
+        it('should update URL after `PARAMNAME.changed` messages are published', function() {
+          pubsub.publishSync('param1.changed', {value: 'param1NewValue'});
+          expect(locationFake.hash).to.be.equal('#param1NewValue/' + opts.params.param2);
+          pubsub.publishSync('param2.changed', {value: 'param2NewValue'});
+          expect(locationFake.hash).to.be.equal('#param1NewValue/param2NewValue');
+          pubsub.publishSync('param3.changed', {value: 'param3NewValue'});
+          expect(locationFake.hash).to.be.equal('#param1NewValue/param2NewValue?param3=param3NewValue');
+        });
+
+        it('should publish `PARAMNAME.changed` messages for new values after onhashchange', function() {
+          locationFake.href = '/base#param1NewValue?param3=param3NewValue';
+          var spy = sinon.spy(pubsub, 'publish');
+          window.onhashchange();
+          expect(spy).to.have.been.calledTwice;
+          expect(spy).to.have.been.calledWith('param1.changed', {value: 'param1NewValue'});
+          expect(spy).to.have.been.calledWith('param3.changed', {value: 'param3NewValue'});
+          pubsub.publish.restore();
         });
       });
-
     });
 });


### PR DESCRIPTION
- Adiciona testes unitários para os módulos `DataTable` e `UrlManager`
- Adiciona relatório de cobertura de testes com pequeno sumário no terminal e criação de relatório detalhado na pasta _coverage_
- Adiciona a task _watch_ ao fabric como atalho para a task de mesmo nome do Gulp, que "compila" o _static_ a cada alteração em algum arquivo
- Adiciona a taks _tdd_ ao fabric e ao Gulp para ficar observando modificações no código em javascript e executar os testes automaticamente 
- Instala o SinonJS e faz a integração do SinonJS com o Chai e do jQuery também com o Chai

https://github.com/domenic/sinon-chai
https://github.com/chaijs/chai-jquery
